### PR TITLE
use Guard::Compat + update to RSpec 3.1

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,10 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.verbose = (ENV['CI'] == 'true')
+end
+
 RuboCop::RakeTask.new(:style)
 
 namespace :ci do

--- a/guard-rubocop.gemspec
+++ b/guard-rubocop.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'guard',   '~> 2.0'
+  spec.add_runtime_dependency 'guard-compat',   '~> 1.1'
   spec.add_runtime_dependency 'rubocop', '~> 0.20'
 
   spec.add_development_dependency 'bundler',     '~> 1.3'

--- a/guard-rubocop.gemspec
+++ b/guard-rubocop.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler',     '~> 1.3'
   spec.add_development_dependency 'rake',        '~> 10.0'
-  spec.add_development_dependency 'rspec',       '~> 3.0'
+  spec.add_development_dependency 'rspec',       '~> 3.1'
   spec.add_development_dependency 'simplecov',   '~> 0.7'
   spec.add_development_dependency 'guard-rspec', '>= 4.2.3', '< 5.0'
   spec.add_development_dependency 'ruby_gntp',   '~> 0.3'

--- a/lib/guard/rubocop.rb
+++ b/lib/guard/rubocop.rb
@@ -1,7 +1,8 @@
 # coding: utf-8
 
-require 'guard'
-require 'guard/plugin'
+require 'tempfile'
+
+require 'guard/compat/plugin'
 
 module Guard
   # This class gets API calls from `guard` and runs `rubocop` command via {Guard::RuboCop::Runner}.
@@ -30,7 +31,7 @@ module Guard
     end
 
     def run_all
-      UI.info 'Inspecting Ruby code style of all files'
+      Compat::UI.info 'Inspecting Ruby code style of all files'
       inspect_with_rubocop
     end
 
@@ -55,7 +56,7 @@ module Guard
       return if paths.empty?
 
       displayed_paths = paths.map { |path| smart_path(path) }
-      UI.info "Inspecting Ruby code style: #{displayed_paths.join(' ')}"
+      Compat::UI.info "Inspecting Ruby code style: #{displayed_paths.join(' ')}"
 
       inspect_with_rubocop(paths)
     end
@@ -65,8 +66,8 @@ module Guard
       passed = runner.run(paths)
       @failed_paths = runner.failed_paths
       throw :task_has_failed unless passed
-    rescue => error
-      UI.error 'The following exception occurred while running guard-rubocop: ' \
+    rescue StandardError => error
+      Compat::UI.error 'The following exception occurred while running guard-rubocop: ' \
                "#{error.backtrace.first} #{error.message} (#{error.class.name})"
     end
 

--- a/lib/guard/rubocop/runner.rb
+++ b/lib/guard/rubocop/runner.rb
@@ -88,7 +88,7 @@ module Guard
 
       def notify(passed)
         image = passed ? :success : :failed
-        Notifier.notify(summary_text, title: 'RuboCop results', image: image)
+        Compat::UI.notify(summary_text, title: 'RuboCop results', image: image)
       end
 
       def summary_text

--- a/spec/guard/rubocop/runner_spec.rb
+++ b/spec/guard/rubocop/runner_spec.rb
@@ -1,8 +1,10 @@
 # coding: utf-8
 
-require 'spec_helper.rb'
+require 'guard/compat/test/helper'
 
-describe Guard::RuboCop::Runner do
+require 'guard/rubocop'
+
+RSpec.describe Guard::RuboCop::Runner do
   subject(:runner) { Guard::RuboCop::Runner.new(options) }
   let(:options) { {} }
 

--- a/spec/guard/rubocop/runner_spec.rb
+++ b/spec/guard/rubocop/runner_spec.rb
@@ -347,14 +347,14 @@ RSpec.describe Guard::RuboCop::Runner do
     end
 
     it 'notifies summary' do
-      expect(Guard::Notifier).to receive(:notify) do |message, _options|
+      expect(Guard::Compat::UI).to receive(:notify) do |message, _options|
         expect(message).to eq('2 files inspected, 4 offenses detected')
       end
       runner.notify(true)
     end
 
     it 'notifies with title "RuboCop results"' do
-      expect(Guard::Notifier).to receive(:notify) do |_message, options|
+      expect(Guard::Compat::UI).to receive(:notify) do |_message, options|
         expect(options[:title]).to eq('RuboCop results')
       end
       runner.notify(true)
@@ -362,7 +362,7 @@ RSpec.describe Guard::RuboCop::Runner do
 
     context 'when passed' do
       it 'shows success image' do
-        expect(Guard::Notifier).to receive(:notify) do |_message, options|
+        expect(Guard::Compat::UI).to receive(:notify) do |_message, options|
           expect(options[:image]).to eq(:success)
         end
         runner.notify(true)
@@ -371,7 +371,7 @@ RSpec.describe Guard::RuboCop::Runner do
 
     context 'when failed' do
       it 'shows failed image' do
-        expect(Guard::Notifier).to receive(:notify) do |_message, options|
+        expect(Guard::Compat::UI).to receive(:notify) do |_message, options|
           expect(options[:image]).to eq(:failed)
         end
         runner.notify(false)

--- a/spec/guard/rubocop/template_spec.rb
+++ b/spec/guard/rubocop/template_spec.rb
@@ -1,0 +1,18 @@
+require 'guard/compat/test/template'
+
+require 'guard/rubocop'
+
+RSpec.describe Guard::RuboCop do
+  describe 'template' do
+    subject { Guard::Compat::Test::Template.new(described_class) }
+
+    it 'matches Ruby files' do
+      expect(subject.changed('lib/foo.rb')).to eq(%w(lib/foo.rb))
+    end
+
+    it 'matches .rubocop.yml files' do
+      expect(subject.changed('.rubocop.yml')).to eq(%w(.))
+      expect(subject.changed('foo/.rubocop.yml')).to eq(%w(foo))
+    end
+  end
+end

--- a/spec/guard/rubocop_spec.rb
+++ b/spec/guard/rubocop_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe Guard::RuboCop, :silence_output do
   subject(:guard) { Guard::RuboCop.new(options) }
   let(:options) { {} }
 
+  before do
+    allow(Guard::Compat::UI).to receive(:info)
+    allow(Guard::Compat::UI).to receive(:error)
+  end
+
   describe '#options' do
     subject { super().options }
 

--- a/spec/guard/rubocop_spec.rb
+++ b/spec/guard/rubocop_spec.rb
@@ -1,8 +1,6 @@
 # coding: utf-8
 
-require 'spec_helper.rb'
-
-describe Guard::RuboCop, :silence_output do
+RSpec.describe Guard::RuboCop, :silence_output do
   subject(:guard) { Guard::RuboCop.new(options) }
   let(:options) { {} }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,26 @@
-# coding: utf-8
-
 RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
-  config.mock_with :rspec do |c|
-    c.syntax = :expect
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
   end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
+  config.disable_monkey_patching!
+
+  config.warnings = true
+
+  config.default_formatter = 'doc' if config.files_to_run.one?
+
+  # config.profile_examples = 10
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end
 
 Dir[File.join(File.dirname(__FILE__), 'support', '*')].each do |path|
@@ -29,5 +42,3 @@ SimpleCov.start do
   add_filter '/spec/'
   add_filter '/vendor/bundle/'
 end
-
-require 'guard/rubocop'

--- a/spec/support/silence_output.rb
+++ b/spec/support/silence_output.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-shared_context 'silence output', silence_output: true do
+RSpec.shared_context 'silence output', silence_output: true do
   null_object = BasicObject.new
 
   class << null_object


### PR DESCRIPTION
Also:
- add specs for Guardfile templates
- suppress additional info when running Rake locally
