### PR TITLE
Fix the test suite to run against latest Guard.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,4 +30,9 @@ SimpleCov.start do
   add_filter '/vendor/bundle/'
 end
 
+# Initialize Guard for running tests.
+require 'guard'
+Guard.setup(notify: false)
+
 require 'guard/rubocop'
+


### PR DESCRIPTION
The test suite works fine with Guard 2.1, but fails with Guard 2.13.

The failure comes from heavy refactoring in recent version of Guard,
where static initialization is expected by the runtime. The init just
does not happen when running the test suite.

guard-compat seems to address the problem, but it was not updated for a
year at time of writing, and this commit is pretty simple in the end.

The tests remain untouched and all pass.
